### PR TITLE
fix: corrected composer vendor name

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,11 @@ This is a BETA release for MageOS web installer.
 ```shell
 composer create-project --repository-url=https://repo.mage-os.org/ mage-os/project-community-edition .
 ```
-3. Download this module with
+
+2. Download this module with
 ```shell
 composer config repositories.web-installer vcs https://github.com/mage-os-lab/web-installer
-composer require --dev mageos/web-installer dev-main
+composer require --dev mage-os/web-installer dev-main
 ```
-4. Open your browser to your virtual host name and you should get redirected to `/setup`
+
+3. Open your browser to your virtual host name and you should get redirected to `/setup`

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "mageos/web-installer",
+  "name": "mage-os/web-installer",
   "description": "MageOS - Web - Installer",
   "type": "magento2-component",
   "authors": [
@@ -14,7 +14,6 @@
     "OSL-3.0",
     "AFL-3.0"
   ],
-  "version": "1.0.0",
   "extra": {
     "map": [
       [


### PR DESCRIPTION
Composer vendor should be `mage-os` to match other packages. Also updated the readme, and removed the version tag from `composer.json` (that'll get added during release generation).